### PR TITLE
Add server configuration to run on port 3000

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node src/index.js

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Synapse is designed to seamlessly merge AI prowess with human ingenuity, creatin
 ## Getting Started
 Instructions on how to set up the project.
 
+## Running the Server Locally
+To run the server locally, use the following command:
+```
+node src/index.js
+```
+
+## Accessing Synapse Locally
+Once the server is running, you can access Synapse locally at:
+```
+http://localhost:3000
+```
+
 ## Contributing
 Guidelines on how to contribute to the project.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+app.get('/', (req, res) => {
+  res.send('Synapse is running');
+});
+
+app.listen(port, () => {
+  console.log(`Server is up and running on port ${port}`);
+});


### PR DESCRIPTION
Add server configuration to run on port 3000 and update documentation.

* **src/index.js**: Create a basic Express server that listens on port 3000 and responds with "Synapse is running" on the root route.
* **Procfile**: Add the line `web: node src/index.js` to specify the command to run the server for Heroku deployment.
* **README.md**: Add instructions to run the server locally using `node src/index.js` and access Synapse locally at `http://localhost:3000`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/Synapse?shareId=51da51d7-7258-4e01-acad-c726e23c8947).